### PR TITLE
fix image tag in readme

### DIFF
--- a/Proline/Nextflow/README.md
+++ b/Proline/Nextflow/README.md
@@ -5,7 +5,7 @@ The provided workflow is based on the docker image veitveit/prolineworkflow that
 You can also create the image by the following command:
 ```
 # main.nf workflow image creation
-docker build -t "veitveit/veitveit/prolineworkflow:dev" .
+docker build -t "veitveit/prolineworkflow:dev" .
 
 ```
 


### PR DESCRIPTION
Hey,
only a little typo or copy/paste error in the readme-file. Now it matches the image specified in the `nextflow.config`

Best Regards,
Dirk